### PR TITLE
feat(api): new api with clean url

### DIFF
--- a/api/_utils/extract-http-error.ts
+++ b/api/_utils/extract-http-error.ts
@@ -1,0 +1,20 @@
+import { HTTPError } from "got";
+
+export interface HttpErrorInfo {
+  code: number;
+  message: string;
+}
+
+export function extractInfoFromHttpError(
+  err: unknown,
+  defaults: HttpErrorInfo,
+) {
+  if (err instanceof HTTPError) {
+    const code =
+      (err.code && parseInt(err.code)) ||
+      err.response.statusCode ||
+      defaults.code;
+    const message = err.message;
+    return { code, message };
+  } else return defaults;
+}

--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/([^/]+)(/)?",
+      "destination": "/$1/index.html"
+    },
+    {
+      "source": "/:url((?:[^?]+/)+[^?]+){\\?:commit(.+)}?",
+      "destination": "/api/pkg"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "scripts": {
     "lint": "eslint --ext .js,.ts",
-    "dev": "yarn run docs:dev --port $PORT",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "build": "vuepress build docs"


### PR DESCRIPTION
now you can use the following url to download a package:

```
https://gitpkg.now.sh/<repo><subfolder>[?<commit-ish>]
https://gitpkg.now.sh/EqualMa/gitpkg-example/packages/hello?feat/emoji
```
