### PR TITLE
Shielding the escape of some special symbols

### DIFF
--- a/docs/.vuepress/api-from-url.js
+++ b/docs/.vuepress/api-from-url.js
@@ -54,16 +54,16 @@ function apiFromCommitInfo({
       warnType: "suggest-to-use",
       data,
       suggestion: {
-        apiUrl: commit ? repo + "#" + commit : repo,
+        apiUrl: "'" + commit ? repo + "#" + commit : repo + "'",
       },
-      apiUrl: API_BASE + repo + commitPart,
+      apiUrl: "'" + API_BASE + repo + commitPart + "'",
       params: { url: repo, commit },
     };
   } else {
     return {
       type: "success",
       data,
-      apiUrl: API_BASE + repo + "/" + subdir + commitPart,
+      apiUrl: "'" + API_BASE + repo + "/" + subdir + commitPart + "'",
       params: { url: repo + "/" + subdir, commit },
     };
   }


### PR DESCRIPTION
It's safer to add a single quotation mark before and after the generated URL, here's why:
-$ npm install https://gitpkg.now.sh/vuejs/vuepress/packages/vuepress?master 
-zsh: no matches found: https://gitpkg.now.sh/vuejs/vuepress/packages/vuepress?master

Then this would be work perfectly:
-$ npm install 'https://gitpkg.now.sh/vuejs/vuepress/packages/vuepress?master'