### PR TITLE
fix: sw update popup style

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,6 +42,7 @@ module.exports = async () => {
         "@vuepress/pwa",
         {
           serviceWorker: true,
+          popupComponent: 'my-components/ServiceWorkerPopup',
           updatePopup: true,
           generateSWConfig: {
             importWorkboxFrom: "local",

--- a/docs/.vuepress/my-components/ServiceWorkerPopup.vue
+++ b/docs/.vuepress/my-components/ServiceWorkerPopup.vue
@@ -1,0 +1,41 @@
+<template>
+  <SWUpdatePopup v-slot="{ enabled, reload, message, buttonText }">
+    <div v-if="enabled" class="gitpkg-sw-update-popup">{{ message }}<br>
+      <button @click="reload">{{ buttonText }}</button>
+    </div>
+  </SWUpdatePopup>
+</template>
+
+<script>
+import SWUpdatePopup from '@vuepress/plugin-pwa/lib/SWUpdatePopup.vue'
+
+export default {
+  components: { SWUpdatePopup }
+}
+</script>
+<style lang="stylus" scoped>
+.gitpkg-sw-update-popup
+  position fixed
+  text-align center
+  right 1em
+  bottom 1em
+  padding 1em
+  color black
+  background white
+  border 2px solid $accentColor
+  box-shadow 0.5em 0.5em 2em rgba(0, 0, 0, 0.6)
+  transition all ease 0.2s 0s, box-shadow ease-out 0.4s 0s
+  z-index 2
+
+.gitpkg-sw-update-popup button
+  margin-top 0.5em
+  padding 0.4em 1.8em
+  border-width 0
+  color white
+  background-color $accentColor
+  box-shadow 0.5em 0.5em 1.5em rgba(0, 0, 0, 0.4)
+  
+&:not(:hover):not(:focus)
+  box-shadow 0px 0 1px 0 black
+
+</style>


### PR DESCRIPTION
The default SW-Update Popup looks weird with the pink color of gitpkg theme, like this:

![IMB_h4REJJ](https://user-images.githubusercontent.com/15633984/76995688-2fb54180-698b-11ea-8fe3-74ef837605ec.png)

So I tried to to customize SW-Update Popup’s appearance to fit the default theme of gitpkg by adding `ServiceWorkerPopup.vue`. The border and button color define by `$accentColor` and uses hover animation related to `index.styl`, final result(large gif):

![IMB_WqRtsw](https://user-images.githubusercontent.com/15633984/76996207-14970180-698c-11ea-9b68-a008e95e001b.gif)

Maybe I should commit a issue instead of a pr, I’m new to front-end and nervous about my code quality. Anyway, you could try it better.